### PR TITLE
Fix code format

### DIFF
--- a/docs/topics/jvm-api-guidelines-backward-compatibility.md
+++ b/docs/topics/jvm-api-guidelines-backward-compatibility.md
@@ -195,7 +195,7 @@ data class User(
     val email: String,
     val active: Boolean = true
 ) {
-    constructor(name: String, email: String) : 
+    constructor(name: String, email: String) :
             this(name, email, active = true)
 }
 ```

--- a/docs/topics/jvm-api-guidelines-backward-compatibility.md
+++ b/docs/topics/jvm-api-guidelines-backward-compatibility.md
@@ -64,7 +64,7 @@ fun fib() = … // Returns the fifth element
 Let's call this function from another file, `client.kt`:
 
 ```kotlin
-fun main(){
+fun main() {
     println(fib()) // Returns 3
 }
 ```
@@ -195,7 +195,7 @@ data class User(
     val email: String,
     val active: Boolean = true
 ) {
-    constructor(name: String, email: String): 
+    constructor(name: String, email: String) : 
             this(name, email, active = true)
 }
 ```

--- a/docs/topics/jvm-api-guidelines-backward-compatibility.md
+++ b/docs/topics/jvm-api-guidelines-backward-compatibility.md
@@ -384,11 +384,11 @@ For example, consider this code:
 class Calculator {
     fun add(a: Int, b: Int): Int {
         return a + b
-	}
+    }
 
-	fun multiply(a: Int, b: Int): Int {
+    fun multiply(a: Int, b: Int): Int {
         return a * b
-	}
+    }
 }
 ```
 
@@ -396,17 +396,17 @@ If you add a new method without breaking the compatibility like this:
 
 ```kotlin
 class Calculator {
-	fun add(a: Int, b: Int): Int {
+    fun add(a: Int, b: Int): Int {
         return a + b
-	}
+    }
 
-	fun multiply(a: Int, b: Int): Int {
+    fun multiply(a: Int, b: Int): Int {
         return a * b
-	}
+    }
 
-	fun divide(a: Int, b: Int): Int {
+    fun divide(a: Int, b: Int): Int {
         return a / b
-	}
+    }
 }
 ```
 

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -26,12 +26,12 @@ which could break your code. Instead, you can make `interface JsonElement` _seal
 ```kotlin
 sealed interface JsonElement
 
-class JsonNumber(val value: Number): JsonElement
-class JsonObject(val values: Map<String, JsonElement>): JsonElement
-class JsonArray(val values: List<JsonElement>): JsonElement
-class JsonBoolean(val value: Boolean): JsonElement
-class JsonString(val value: String): JsonElement
-object JsonNull: JsonElement
+class JsonNumber(val value: Number) : JsonElement
+class JsonObject(val values: Map<String, JsonElement>) : JsonElement
+class JsonArray(val values: List<JsonElement>) : JsonElement
+class JsonBoolean(val value: Boolean) : JsonElement
+class JsonString(val value: String) : JsonElement
+object JsonNull : JsonElement
 ```
 
 This approach helps you avoid mistakes on both the library and client side.
@@ -40,7 +40,7 @@ The key benefit of using sealed classes comes into play when you use them in a `
 to verify that the statement covers all cases, you don't need to add an `else` clause to the statement:
 
 ```kotlin
-fun processJson(json: JsonElement) = when(json) {
+fun processJson(json: JsonElement) = when (json) {
     is JsonNumber -> { /* Process as a number */ }
     is JsonObject -> { /* Process as an object */ }
     is JsonArray -> { /* Process as an array */ }
@@ -117,16 +117,16 @@ you can't read from an already closed input stream.
 Consider the class `InputStream` with a `readByte()` method and its usage:
 
 ```kotlin
-class InputStream: Closeable {
+class InputStream : Closeable {
     private var open = true
-    fun readByte(): Byte { /* Read and return one byte */}
+    fun readByte(): Byte { /* Read and return one byte */ }
     override fun close(): Unit { 
         /* Dispose of the underlying resource */ 
         open = false
     }
 }
 
-fun readTwoBytes(inputStream: InputStream): Pair<Byte, Byte>{
+fun readTwoBytes(inputStream: InputStream): Pair<Byte, Byte> {
     val first = inputStream.use { it.readByte() }
     val second = inputStream.readByte()
     return Pair(first, second)
@@ -139,7 +139,7 @@ the code of the `readByte()` function:
 
 ```kotlin
 fun readByte(): Byte {
-    check(open) {"Can't read from the already closed stream"}
+    check(open) { "Can't read from the already closed stream" }
     // Read and return one byte
 }
 ```

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -90,15 +90,15 @@ check that `username` is unique and not empty even if you have already defined t
 
 ```kotlin
 fun saveUser(username: String, password: String) {
-	require(username.isNotBlank()) { "Username should not be blank" }
-	require(api.usernameAvailable(username)) { "Username $username is already taken" }
-	require(password.isNotBlank()) { "Password should not be blank" }
-	require(password.length > 6) { "Password should contain at least 7 letters" }
-	require(
+    require(username.isNotBlank()) { "Username should not be blank" }
+    require(api.usernameAvailable(username)) { "Username $username is already taken" }
+    require(password.isNotBlank()) { "Password should not be blank" }
+    require(password.length > 6) { "Password should contain at least 7 letters" }
+    require(
         /* Some complex check */
-	) { "..." }
+    ) { "..." }
 
-	api.saveUser(User(username, password))
+    api.saveUser(User(username, password))
 }
 ```
 
@@ -121,7 +121,7 @@ class InputStream: Closeable {
     private var open = true
     fun readByte(): Byte { /* Read and return one byte */}
     override fun close(): Unit { 
-    /* Dispose of the underlying resource */ 
+        /* Dispose of the underlying resource */ 
         open = false
     }
 }
@@ -180,7 +180,7 @@ fun printElements(delimiter: String, vararg elements: String) {
     for (i in elements.indices) {
         print(elements[i])
         if (i < elements.lastIndex) print(delimiter)
-	}
+    }
 }
 
 fun printWithSpace(vararg elements: String) {

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -122,7 +122,7 @@ class InputStream : Closeable {
     fun readByte(): Byte { /* Read and return one byte */
     }
     override fun close() {
-        /* Dispose of the underlying resource */
+        // Dispose of the underlying resource
         open = false
     }
 }

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -120,8 +120,8 @@ Consider the class `InputStream` with a `readByte()` method and its usage:
 class InputStream : Closeable {
     private var open = true
     fun readByte(): Byte { /* Read and return one byte */ }
-    override fun close(): Unit { 
-        /* Dispose of the underlying resource */ 
+    override fun close(): Unit {
+        /* Dispose of the underlying resource */
         open = false
     }
 }

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -119,8 +119,9 @@ Consider the class `InputStream` with a `readByte()` method and its usage:
 ```kotlin
 class InputStream : Closeable {
     private var open = true
-    fun readByte(): Byte { /* Read and return one byte */ }
-    override fun close(): Unit {
+    fun readByte(): Byte { /* Read and return one byte */
+    }
+    override fun close() {
         /* Dispose of the underlying resource */
         open = false
     }

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -41,13 +41,13 @@ A canonical example of a Kotlin builder DSL is `kotlinx.html`. Consider this exa
 
 ```kotlin
 header("modal-card-head") {
-  p("modal-card-title") {
-    +book.book.name
-  }
-  button(classes = "delete") {
-    attributes["aria-label"] = "close"
-    attributes["_"] = closeModalScript
-  }
+    p("modal-card-title") {
+        +book.book.name
+    }
+    button(classes = "delete") {
+        attributes["aria-label"] = "close"
+        attributes["_"] = closeModalScript
+    }
 }
 ```
 
@@ -55,21 +55,21 @@ It could be implemented as a traditional builder. But this is considerably more 
 
 ```kotlin
 headerBuilder()
-   .addClasses("modal-card-head")
-   .addElement(
-       pBuilder()
-           .addClasses("modal-card-title")
-           .addContent(book.book.name)
-           .build()
-   )
-   .addElement(
-       buttonBuilder()
-           .addClasses("delete")
-           .addAttribute("aria-label", "close")
-           .addAttribute("_", closeModalScript)
-           .build()
-   )
-   .build()
+    .addClasses("modal-card-head")
+    .addElement(
+        pBuilder()
+            .addClasses("modal-card-title")
+            .addContent(book.book.name)
+            .build()
+    )
+    .addElement(
+        buttonBuilder()
+            .addClasses("delete")
+            .addAttribute("aria-label", "close")
+            .addAttribute("_", closeModalScript)
+            .build()
+    )
+    .build()
 ```
 
 It has too many details that you don't necessarily need to know and requires you to build each entity at the end.
@@ -79,9 +79,9 @@ to instantiate a variable and dynamically overwrite it:
 
 ```kotlin
 var buttonBuilder = buttonBuilder()
-   .addClasses("delete")
+    .addClasses("delete")
 for((attributeName, attributeValue) in attributes){
-   buttonBuilder= buttonBuilder.addAttribute(attributeName, attributeValue)
+    buttonBuilder= buttonBuilder.addAttribute(attributeName, attributeValue)
 }
 buttonBuilder.build()
 ```
@@ -90,11 +90,11 @@ Inside the builder DSL, you can directly call a loop and all necessary DSL calls
 
 ```kotlin
 div("tags") {
-  for (genre in book.genres) {
-    span("tag is-rounded is-normal is-info is-light") {
-      +genre
+    for (genre in book.genres) {
+        span("tag is-rounded is-normal is-info is-light") {
+            +genre
+        }
     }
-  }
 }
 ```
 
@@ -189,21 +189,21 @@ For example, consider a class for a graph:
 ```kotlin
 class Graph {
     private val _vertices: MutableSet<Int> = mutableSetOf()
-	private val _edges: MutableMap<Int, MutableSet<Int>> = mutableMapOf()
+    private val _edges: MutableMap<Int, MutableSet<Int>> = mutableMapOf()
 
-	fun addVertex(vertex: Int) {
+    fun addVertex(vertex: Int) {
         _vertices.add(vertex)
-	}
+    }
 
-	fun addEdge(vertex1: Int, vertex2: Int) {
+    fun addEdge(vertex1: Int, vertex2: Int) {
         _vertices.add(vertex1)
         _vertices.add(vertex2)
         _edges.getOrPut(vertex1) { mutableSetOf() }.add(vertex2)
         _edges.getOrPut(vertex2) { mutableSetOf() }.add(vertex1)
-	}
+    }
 
-	val vertices: Set<Int> get() = _vertices
-        val edges: Map<Int, Set<Int>> get() = _edges
+    val vertices: Set<Int> get() = _vertices
+    val edges: Map<Int, Set<Int>> get() = _edges
 }
 ```
 

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -171,7 +171,7 @@ You can write a constructor-like function to lower the [cognitive complexity](jv
 of your code and reduce the size of your API:
 
 ```kotlin
-fun <T>  List(): List<T> = EmptyList
+fun <T> List(): List<T> = EmptyList
 
 // Usage of the code above:
 public fun <T> listOf(vararg elements: T): List<T> =

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -80,8 +80,8 @@ to instantiate a variable and dynamically overwrite it:
 ```kotlin
 var buttonBuilder = buttonBuilder()
     .addClasses("delete")
-for((attributeName, attributeValue) in attributes){
-    buttonBuilder= buttonBuilder.addAttribute(attributeName, attributeValue)
+for ((attributeName, attributeValue) in attributes) {
+    buttonBuilder = buttonBuilder.addAttribute(attributeName, attributeValue)
 }
 buttonBuilder.build()
 ```
@@ -238,7 +238,7 @@ mapNotNull(transform: (T) -> R?)
 It was possible to add something like `map(filterNulls: Boolean)` and write code like this:
 
 ```kotlin
-listOf(1, null, 2).map(false){ it.toString() }
+listOf(1, null, 2).map(false) { it.toString() }
 ```
 
 From reading this code, it's tough to infer what `false` actually means. However, if you use the `mapNotNull()` function, 


### PR DESCRIPTION
This PR formats code blocks according to the Kotlin [coding conventions](https://kotlinlang.org/docs/coding-conventions.html).


### Changes:

1. Use four spaces for indentation ([convention](https://kotlinlang.org/docs/coding-conventions.html#indentation)).
2. Add missing spaces + Remove extra spaces ([convention](https://kotlinlang.org/docs/coding-conventions.html#horizontal-whitespace)).
3. Remove explicit Unit return type ([convention](https://kotlinlang.org/docs/coding-conventions.html#unit-return-type)).
4. Replace multi-line comments with single-line.
