### PR TITLE
Some minor style nitpicks

### DIFF
--- a/docs/topics/jvm-api-guidelines-backward-compatibility.md
+++ b/docs/topics/jvm-api-guidelines-backward-compatibility.md
@@ -314,8 +314,8 @@ with `@OptIn(RequiresFullKotlinReflection::class)`.
 
 You should try to keep your API as transparent as possible. To force the API to be transparent, use the [explicit API mode](whatsnew14.md#explicit-api-mode-for-library-authors).
 
-Kotlin gives you vast freedom in how you can write code. It is possible to omit type definitions, omit visibility declarations, 
-or omit documentation. The explicit API mode forces you as a developer to make implicit things explicit. 
+Kotlin gives you vast freedom in how you can write code. It is possible to omit type definitions, visibility declarations, 
+or documentation. The explicit API mode forces you as a developer to make implicit things explicit. 
 By the link above, you can find out how to enable it. Let's try to understand why you might need it:
 
 1. Without an explicit API, it's easier to break backward compatibility:

--- a/docs/topics/jvm-api-guidelines-backward-compatibility.md
+++ b/docs/topics/jvm-api-guidelines-backward-compatibility.md
@@ -53,7 +53,7 @@ to call the updated methods. Adding even [default arguments](functions.md#defaul
 your users' code.
 
 Breaking backward compatibility is shown below in an example of two classes: `lib.kt` representing a "library", 
-`client.kt` representing some "client" of this "library". This construct for libraries and their clients is common 
+`client.kt` representing a "client" of this "library". This construct for libraries and their clients is common 
 in real-world applications. In this example, the "library" has one function that computes the fifth member 
 of the Fibonacci sequence. The file `lib.kt` contains:
 
@@ -147,12 +147,12 @@ public final class LibKt {
 The method with signature `public static final int fib()` was replaced with a new method with signature 
 `public static final int fib(int)` . At the same time, a proxy method `fib$default` delegates the execution to `fib(int)`. 
 For JVM, it's possible to work around this: you need to add a [`@JvmOverloads`](java-to-kotlin-interop.md#overloads-generation) 
-annotation. For multiplatform projects, there is unfortunately no workaround.
+annotation. For multiplatform projects, there is no workaround.
 
 ### Don't use data classes in API
 
-[Data classes](data-classes.md) are tempting to use because they are short, concise, and have some functionality 
-out of the box. However, due to some specifics of how data classes work, it's better not to use them in library APIs. 
+[Data classes](data-classes.md) are tempting to use because they are short, concise, and provide some nice functionality 
+out of the box. However, due to specifics of how data classes work, it's better not to use them in library APIs. 
 Almost any change makes the API not backward compatible.
 
 Usually, it's hard to predict how you will need to change a class over time. Even if today you think that it's self-contained, 
@@ -170,7 +170,7 @@ data class User(
 )
 ```
 
-For example, over some time, you understand that users should go through an activation procedure, so you want to add 
+For example, over time, you understand that users should go through an activation procedure, so you want to add 
 a new field, "active" with a default value equal to "true". This new field should allow the existing code to work 
 mostly without changes.
 
@@ -236,7 +236,7 @@ In addition, if you add a field into the class's body, you have to override the 
 
 Sometimes, especially when you don't use [explicit API mode](whatsnew14.md#explicit-api-mode-for-library-authors), 
 a return type declaration can change implicitly. But even if it's not the case, you might want to narrow the signature. 
-For example, sometimes you realize that you need index access to the elements of your collection and want to change 
+For example, if you realize that you need index access to the elements of your collection and want to change 
 the return type from `Collection` to `RandomAccess`. This section describes why it is a bad idea for a library author 
 to make such a change.
 
@@ -314,8 +314,8 @@ with `@OptIn(RequiresFullKotlinReflection::class)`.
 
 You should try to keep your API as transparent as possible. To force the API to be transparent, use the [explicit API mode](whatsnew14.md#explicit-api-mode-for-library-authors).
 
-Kotlin gives you vast freedom in how you can write code. It is possible not to define types, omit visibility declarations, 
-or omit documentation for something. The explicit API mode forces you as a developer to make implicit things explicit. 
+Kotlin gives you vast freedom in how you can write code. It is possible to omit type definitions, omit visibility declarations, 
+or omit documentation. The explicit API mode forces you as a developer to make implicit things explicit. 
 By the link above, you can find out how to enable it. Let's try to understand why you might need it:
 
 1. Without an explicit API, it's easier to break backward compatibility:
@@ -382,13 +382,8 @@ For example, consider this code:
 
 ```kotlin
 class Calculator {
-    fun add(a: Int, b: Int): Int {
-        return a + b
-    }
-
-    fun multiply(a: Int, b: Int): Int {
-        return a * b
-    }
+    fun add(a: Int, b: Int): Int = a + b
+    fun multiply(a: Int, b: Int): Int = a * b
 }
 ```
 
@@ -396,17 +391,9 @@ If you add a new method without breaking the compatibility like this:
 
 ```kotlin
 class Calculator {
-    fun add(a: Int, b: Int): Int {
-        return a + b
-    }
-
-    fun multiply(a: Int, b: Int): Int {
-        return a * b
-    }
-
-    fun divide(a: Int, b: Int): Int {
-        return a / b
-    }
+    fun add(a: Int, b: Int): Int = a + b
+    fun multiply(a: Int, b: Int): Int = a * b
+    fun divide(a: Int, b: Int): Int = a / b
 }
 ```
 

--- a/docs/topics/jvm-api-guidelines-debuggability.md
+++ b/docs/topics/jvm-api-guidelines-debuggability.md
@@ -31,9 +31,8 @@ Neither is the information provided in the debug tool window:
 To make both logging and debugging much more readable, add a simple `toString()` implementation like this:
 
 ```kotlin
-override fun toString(): String {
-    return "Vector2D(x=$x, y=$y)"
-}
+override fun toString(): String =
+    "Vector2D(x=$x, y=$y)"
 ```
 
 This results in improved output:
@@ -52,7 +51,7 @@ This results in improved output:
 
 Consider implementing `toString()` even if you don't think the class is going to be printed anywhere, as it can help in 
 unexpected ways. For example, inside [builders](https://en.wikipedia.org/wiki/Builder_pattern#:~:text=The%20builder%20pattern%20is%20a,Gang%20of%20Four%20design%20patterns), 
-it sometimes may be important if it's the same builder or a new one.
+it may be important to see current state of the builder.
 
 ```kotlin
 class Person(
@@ -60,9 +59,8 @@ class Person(
     val age: Int?,
     val children: List<Person>
 ) {
-    override fun toString(): String {
-        return "Person(name=$name, age=$age, children=$children)"
-    }
+    override fun toString(): String =
+        "Person(name=$name, age=$age, children=$children)"
 }
 
 class PersonBuilder {
@@ -93,9 +91,8 @@ a non-descriptive string in debug output:
 If you add a simple `toString()` implementation like this:
 
 ```kotlin
-override fun toString(): String {
-    return "PersonBuilder(name=$name, age=$age, children=$children)"
-}
+override fun toString(): String =
+    "PersonBuilder(name=$name, age=$age, children=$children)"
 ```
 
 The debug data becomes much clearer:
@@ -104,7 +101,7 @@ The debug data becomes much clearer:
 
 You can also see immediately which fields are set and which are not.
 
-> Be careful with exposing fields in `toString()` because sometimes it's easy to get a `StackOverflowException`. 
+> Be careful with exposing fields in `toString()` because it might be easy to get a `StackOverflowException`. 
 > For example, if `children` has a reference to a parent, that would create a circular reference. Also, be careful about 
 > exposing lists and maps as `toString()` can expand a deeply-nested hierarchy.
 >

--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -65,10 +65,10 @@ sealed interface DBResponse {
 }
 ```
 
-Exposing this interface implementation – for example, `SQLiteResponse` or `MongoResponse` – to API users is 
+Exposing this interface implementation, for example, `SQLiteResponse` or `MongoResponse`, to API users is 
 a **leaky abstraction**, and it complicates support of this API. In such a library, you might handle only your implementations 
-of `DBResponse`. If, at some moment, a user puts their implementation of `DBResponse` into a library's method 
-accepting responses, it can cause an error. Using sealed interfaces and classes can protect you from this.
+of `DBResponse`. If a user puts their implementation of `DBResponse` into a library's method 
+accepting responses, it can cause an error. Using sealed interfaces and classes protects you from this.
 
 ## Validate your inputs and state
 
@@ -77,7 +77,7 @@ accepting responses, it can cause an error. Using sealed interfaces and classes 
 It's possible to misuse an API. To help your users work with your API correctly, you should validate inputs and the internal 
 state as early as possible with the [require()](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/require.html) function.
 
-For example, this is a simple library function that saves some users to some external API:
+For example, this is a simple library function that saves users to some external API:
 
 ```kotlin
 fun saveUser(username: String, password: String) {
@@ -85,7 +85,7 @@ fun saveUser(username: String, password: String) {
 }
 ```
 
-You should perform some validation on its arguments to make sure that everything behaves as expected. For example, 
+You should perform validation on the function's arguments to make sure that everything behaves as expected. For example, 
 check that `username` is unique and not empty even if you have already defined these constraints in your database:
 
 ```kotlin

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -235,7 +235,7 @@ fun map(transform: (T) -> R): List<R>
 fun mapNotNull(transform: (T) -> R?): List<R>
 ```    
 
-It is possible to add something like `map(filterNulls: Boolean)` and write code like this:
+It was possible to add something like `map(filterNulls: Boolean)` and write code like this:
 
 ```kotlin
 listOf(1, null, 2).map(false) { it.toString() }

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -74,7 +74,7 @@ headerBuilder()
 
 It has too many details that you don't necessarily need to know and requires you to build each entity at the end.
 
-The situation worsens further if you need to generate something dynamically in a loop. In this scenario, you have 
+The situation worsens further if you need to generate builder's content dynamically in a loop. In this scenario, you have 
 to instantiate a variable and dynamically overwrite it:
 
 ```kotlin
@@ -119,11 +119,11 @@ fun a(block: A.() -> Unit): A
 
 ## Use constructor-like functions where applicable
 
-Sometimes, it makes sense to simplify your API's appearance by using constructor-like functions. A constructor-like function 
-is a function whose name starts with a capital letter so it looks like a constructor. This approach can make your library 
+Sometimes, you can simplify your API's appearance by using constructor-like functions. A constructor-like function 
+is a function whose name starts with a capital letter, so it looks like a constructor. This approach can make your library 
 easier to understand.
 
-For example, you want to introduce some [Option type](https://en.wikipedia.org/wiki/Option_type) in your library:
+For example, you want to introduce an [Option type](https://en.wikipedia.org/wiki/Option_type) in your library:
 
 ```kotlin
 sealed interface Option<T>
@@ -131,8 +131,8 @@ class Some<T : Any>(val t: T) : Option<T>
 object None : Option<Nothing>
 ```
 
-You can define implementations of all the `Option` interface methods — `map()`, `flatMap()`, and so on. But each time 
-your API users create such an `Option`, they must write some logic and check what they create. For example:
+You can define implementations of all the `Option` interface methods &mdash; `map()`, `flatMap()`, and so on. But each time 
+your API users create such an `Option`, they must write extra logic to check what they create. For example:
 
 ```kotlin
 fun findById(id: Int): Option<Person> {
@@ -151,10 +151,10 @@ fun <T> Option(t: T?): Option<out T & Any> =
 fun findById(id: Int): Option<Person> = Option(db.personById(id))
 ```
 
-Now, creating a valid `Option` is a no-brainer: just call `Option(x)` and you have a null-safe, purely functional Option idiom.
+Now, creating a valid `Option` is a no-brainer &mdash; just call `Option(x)` and you have a null-safe, purely functional Option idiom.
 
-Another use case for using a constructor-like function is when you need to return some "hidden" things: a private instance, 
-or some internal object. For example, let's look at a method from the standard library:
+Another use case for using a constructor-like function is when you need to return "hidden" things: a private instance, 
+or an internal object. For example, let's look at a method from the standard library:
 
 ```kotlin
 public fun <T> listOf(vararg elements: T): List<T> =
@@ -223,7 +223,7 @@ So, only properties, overrides, and accessors should be members.
 ## Avoid using Boolean arguments in functions
 
 It's almost impossible to understand what the purpose of a `Boolean` argument is just by reading code anywhere except 
-in IDEs, for example, on some version control system sites. Using [named arguments](functions.md#named-arguments) can help 
+in IDEs, for example, on a version control system site. Using [named arguments](functions.md#named-arguments) can help 
 to clarify this, but for now in IDEs, there is no way to force developers to use them. Another option is to create a function 
 that contains the action of the `Boolean` argument and give this function a descriptive name.
 
@@ -235,7 +235,7 @@ fun map(transform: (T) -> R): List<R>
 fun mapNotNull(transform: (T) -> R?): List<R>
 ```    
 
-It was possible to add something like `map(filterNulls: Boolean)` and write code like this:
+It is possible to add something like `map(filterNulls: Boolean)` and write code like this:
 
 ```kotlin
 listOf(1, null, 2).map(false) { it.toString() }

--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -131,7 +131,7 @@ class Some<T : Any>(val t: T) : Option<T>
 object None : Option<Nothing>
 ```
 
-You can define implementations of all the `Option` interface methods &mdash; `map()`, `flatMap()`, and so on. But each time 
+You can define implementations of all the `Option` interface methods – `map()`, `flatMap()`, and so on. But each time 
 your API users create such an `Option`, they must write extra logic to check what they create. For example:
 
 ```kotlin
@@ -151,7 +151,7 @@ fun <T> Option(t: T?): Option<out T & Any> =
 fun findById(id: Int): Option<Person> = Option(db.personById(id))
 ```
 
-Now, creating a valid `Option` is a no-brainer &mdash; just call `Option(x)` and you have a null-safe, purely functional Option idiom.
+Now, creating a valid `Option` is a no-brainer – just call `Option(x)` and you have a null-safe, purely functional Option idiom.
 
 Another use case for using a constructor-like function is when you need to return "hidden" things: a private instance, 
 or an internal object. For example, let's look at a method from the standard library:


### PR DESCRIPTION
* Reduce overuse of the word "some". In many cases it is not needed or should be replaced with an indefinite article.
* Use expression body in code examples whenever possible so that code examples are shorter, thus easier to read and more idiomatic.
* Evaluative adverbs like "unfortunately" do not fit the style of documentation. It is better to simply state the facts. "unfortunately no workaround" -> "no workaround".
* Typography: replace "-" (minus sign) with mdash.