### PR TITLE
Updates the `predictability` section to give an example of `values()`…

### DIFF
--- a/docs/topics/jvm-api-guidelines-predictability.md
+++ b/docs/topics/jvm-api-guidelines-predictability.md
@@ -169,6 +169,9 @@ fun main() { Test.values()[0] = Test.B }
 If you cache values inside the enum, the cache will be corrupted after running the code above. If the values are not 
 cached, it's an additional runtime overhead for each call of the `values()` function.
 
+This is the reason why Kotlin deprecated the `values()` functions since version 1.9 and introduced the `entries()`
+function, that returns an immutable set.
+
 ## Avoid varargs
 
 A `vararg` – [variable number of arguments](functions.md#variable-number-of-arguments-varargs) – works as an array 


### PR DESCRIPTION
… function deprecation

refs #16 and #11 