### PR TITLE
Fix typo in readability guidelines

### DIFF
--- a/docs/topics/jvm-api-guidelines-readability.md
+++ b/docs/topics/jvm-api-guidelines-readability.md
@@ -221,7 +221,7 @@ fun Graph.getNumberOfEdges(): Int = edges.size
 fun Graph.getDegree(vertex: Int): Int = edges[vertex]?.size ?: 0
 ```
 
-Only properties, overrides, and accessors should be members.
+Only properties, overrides and accessors should be members.
 
 ## Avoid using Boolean arguments in functions
 


### PR DESCRIPTION
This request removes a useless comma in the section on member and extension functions.