### PR TITLE
Add link for binary compatibility validation in the KGP from 2.2.0

### DIFF
--- a/docs/labels.list
+++ b/docs/labels.list
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE labels SYSTEM "https://resources.jetbrains.com/writerside/1.0/labels-list.dtd">
+<labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/labels.xsd">
+
+    <primary-label id="experimental-general" name="Experimental" short-name="Experimental" href="components-stability.html#stability-levels-explained" color="red">The feature is Experimental. It may be dropped or changed at any time. Use it only for evaluation purposes.</primary-label>
+
+</labels>

--- a/docs/topics/api-guidelines-backward-compatibility.md
+++ b/docs/topics/api-guidelines-backward-compatibility.md
@@ -51,6 +51,13 @@ If you are satisfied with the changes, you can update the existing `.api` file, 
 
 The validator has [experimental support for validating KLibs](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#experimental-klib-abi-validation-support) produced by multiplatform libraries.
 
+### Binary compatibility validation in the Kotlin Gradle plugin
+
+<primary-label ref="experimental-general"/>
+
+Starting with version 2.2.0, the Kotlin Gradle plugin supports binary compatibility validation. For more information,
+see [Binary compatibility validation in the Kotlin Gradle plugin](gradle-binary-compatibility-validation.md).
+
 ## Specify return types explicitly
 
 As discussed in the [Kotlin coding guidelines](coding-conventions.md#coding-conventions-for-libraries),


### PR DESCRIPTION
This PR adds a link to the new page about binary compatibility validation in the Kotlin Gradle plugin that comes in Kotlin 2.2.0.